### PR TITLE
STM-77 인증 부분 Swagger 작성

### DIFF
--- a/src/main/java/com/storm/score/controller/AuthController.java
+++ b/src/main/java/com/storm/score/controller/AuthController.java
@@ -32,13 +32,10 @@ public class AuthController {
 
     @PostMapping("/login")
     @ApiOperation(value = "로그인", notes = "로그인")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "userId", value = "회원 아이디", required = true, dataType = "Long")
-    })
     @ApiResponses(value = {
             @ApiResponse(
                     code = 200,
-                    message = "Successfully signed up",
+                    message = "Successfully signed in",
                     response = com.storm.score.domain.user.User.class,
                     examples = @Example(
                             @ExampleProperty(
@@ -69,5 +66,23 @@ public class AuthController {
     public ResponseEntity<?> refreshAccessToken() {
         return new ResponseEntity<>(HttpStatus.OK);
     }
-    
+
+    @PostMapping("/apple")
+    @ApiOperation(value = "애플 로그인", notes = "애플 로그인")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    code = 200,
+                    message = "Successfully signed in",
+                    response = com.storm.score.domain.user.User.class,
+                    examples = @Example(
+                            @ExampleProperty(
+                                    mediaType = "application/json",
+                                    value = "- userId: 1\n  nickname: 경태\n  email: kt123@example.com\n"
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<?> appleSignIn(@RequestBody User user) {
+        return new ResponseEntity<>(user, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/storm/score/controller/AuthController.java
+++ b/src/main/java/com/storm/score/controller/AuthController.java
@@ -1,0 +1,64 @@
+package com.storm.score.controller;
+
+import com.storm.score.domain.user.User;
+import io.swagger.annotations.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * description    :
+ * packageName    : com.storm.score.controller
+ * fileName       : AuthController
+ * author         : senor14
+ * date           : 2023-12-14
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2023-12-14        senor14       최초 생성
+ */
+@RestController
+@RequestMapping("/api/v1/auth")
+@Api("Auth Management System")
+@ApiResponses(value = {
+        @ApiResponse(code = 401, message = "You are not authorized to view the resource"),
+        @ApiResponse(code = 403, message = "Accessing the resource you were trying to reach is forbidden"),
+        @ApiResponse(code = 404, message = "The resource you were trying to reach is not found")
+})
+public class AuthController {
+
+    @PostMapping("/login")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "userId", value = "회원 아이디", required = true, dataType = "Long")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(
+                    code = 200,
+                    message = "Successfully signed up",
+                    response = com.storm.score.domain.user.User.class,
+                    examples = @Example(
+                            @ExampleProperty(
+                                    mediaType = "application/json",
+                                    value = "- userId: 1\n  nickname: 경태\n  email: kt123@example.com\n"
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<User> login(@RequestBody com.storm.score.domain.user.User user) {
+        return new ResponseEntity<>(user, HttpStatus.OK);
+    }
+
+    @PostMapping("/logout")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    code = 204,
+                    message = "No Content"
+            )
+    })
+    public ResponseEntity<Void> logout() {
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/com/storm/score/controller/AuthController.java
+++ b/src/main/java/com/storm/score/controller/AuthController.java
@@ -85,4 +85,23 @@ public class AuthController {
     public ResponseEntity<?> appleSignIn(@RequestBody User user) {
         return new ResponseEntity<>(user, HttpStatus.OK);
     }
+
+    @PostMapping("/kakao")
+    @ApiOperation(value = "카카오 로그인", notes = "카카오 로그인")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    code = 200,
+                    message = "Successfully signed in",
+                    response = com.storm.score.domain.user.User.class,
+                    examples = @Example(
+                            @ExampleProperty(
+                                    mediaType = "application/json",
+                                    value = "- userId: 1\n  nickname: 경태\n  email: kt123@example.com\n"
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<?> kakaoSignIn(@RequestBody User user) {
+        return new ResponseEntity<>(user, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/storm/score/controller/AuthController.java
+++ b/src/main/java/com/storm/score/controller/AuthController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     @PostMapping("/login")
+    @ApiOperation(value = "로그인", notes = "로그인")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "userId", value = "회원 아이디", required = true, dataType = "Long")
     })
@@ -52,6 +53,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
+    @ApiOperation(value = "로그아웃", notes = "로그아웃")
     @ApiResponses(value = {
             @ApiResponse(
                     code = 204,
@@ -61,4 +63,11 @@ public class AuthController {
     public ResponseEntity<Void> logout() {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+
+    @PostMapping("/token/refresh")
+    @ApiOperation(value = "토큰 재발급", notes = "토큰 재발급")
+    public ResponseEntity<?> refreshAccessToken() {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+    
 }

--- a/src/main/java/com/storm/score/controller/UserController.java
+++ b/src/main/java/com/storm/score/controller/UserController.java
@@ -401,4 +401,25 @@ public class UserController {
     public ResponseEntity<com.storm.score.domain.user.User> signUp(@RequestBody com.storm.score.domain.user.User user) {
         return new ResponseEntity<>(user, HttpStatus.OK);
     }
+
+    @PostMapping("/login")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "userId", value = "회원 아이디", required = true, dataType = "Long")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(
+                    code = 200,
+                    message = "Successfully signed up",
+                    response = com.storm.score.domain.user.User.class,
+                    examples = @Example(
+                            @ExampleProperty(
+                                    mediaType = "application/json",
+                                    value = "- userId: 1\n  nickname: 경태\n  email: kt123@example.com\n"
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<com.storm.score.domain.user.User> login(@RequestBody com.storm.score.domain.user.User user) {
+        return new ResponseEntity<>(user, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/storm/score/controller/UserController.java
+++ b/src/main/java/com/storm/score/controller/UserController.java
@@ -401,36 +401,4 @@ public class UserController {
     public ResponseEntity<com.storm.score.domain.user.User> signUp(@RequestBody com.storm.score.domain.user.User user) {
         return new ResponseEntity<>(user, HttpStatus.OK);
     }
-
-    @PostMapping("/login")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "userId", value = "회원 아이디", required = true, dataType = "Long")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(
-                    code = 200,
-                    message = "Successfully signed up",
-                    response = com.storm.score.domain.user.User.class,
-                    examples = @Example(
-                            @ExampleProperty(
-                                    mediaType = "application/json",
-                                    value = "- userId: 1\n  nickname: 경태\n  email: kt123@example.com\n"
-                            )
-                    )
-            )
-    })
-    public ResponseEntity<com.storm.score.domain.user.User> login(@RequestBody com.storm.score.domain.user.User user) {
-        return new ResponseEntity<>(user, HttpStatus.OK);
-    }
-
-    @PostMapping("/logout")
-    @ApiResponses(value = {
-            @ApiResponse(
-                    code = 204,
-                    message = "No Content"
-            )
-    })
-    public ResponseEntity<Void> logout() {
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-    }
 }

--- a/src/main/java/com/storm/score/controller/UserController.java
+++ b/src/main/java/com/storm/score/controller/UserController.java
@@ -422,4 +422,15 @@ public class UserController {
     public ResponseEntity<com.storm.score.domain.user.User> login(@RequestBody com.storm.score.domain.user.User user) {
         return new ResponseEntity<>(user, HttpStatus.OK);
     }
+
+    @PostMapping("/logout")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    code = 204,
+                    message = "No Content"
+            )
+    })
+    public ResponseEntity<Void> logout() {
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }


### PR DESCRIPTION
- [STM-89 docs: 기본 이메일 로그인 API Swagger 작성]


- [STM-90 docs: 로그아웃 API Swagger 작성]


- [refactor: 인증 API들 AuthController로 이동]


- [STM-147: 액세스 토큰 재발급 API Swagger 작성]


- [STM-88: 애플 로그인 API Swagger 작성]

- [STM-87: 카카오 로그인 API Swagger 작성]